### PR TITLE
Update mergeTCK.m

### DIFF
--- a/mergeTCK.m
+++ b/mergeTCK.m
@@ -90,3 +90,5 @@ write_mrtrix_tracks(tck_temp, 'output/track.tck')
 % Update user -- NOTE: Update to get subject ID from config file.
 disp(['Finished writing merged TCK file for this subject: ' num2str(tck_temp.total_count) ' total streamlines.'])
 
+exit
+


### PR DESCRIPTION
Jobs were failing because this script never closed matlab and the max wall time would be reached waiting for matlab to close. Adding the exit to the end of this script should fix everything!