### PR TITLE
Update main

### DIFF
--- a/main
+++ b/main
@@ -8,6 +8,4 @@ module load matlab/2019a
 module load mrtrix
 
 matlab -nosplash -nodisplay -r mergeTCK
-
-# Check for output.
-[ ! -s ./output/track.tck ] && exit 1
+[ ! -f ./output/track.tck ] && exit 1


### PR DESCRIPTION
-s checks if file has non-0 filesize. by negating it, we check to make sure file is empty. So the logic is wrong here. I think just checking to make sure file is there should be enough in this case, so I suggest to replace -s with -f (-f is a bit more widely known)